### PR TITLE
updated Dockerfile with current debian stable (bullseye)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:bullseye-slim
 ARG rust_version
 ENV RUST_VERSION ${rust_version}
 ENV RUST_ARCH unknown-linux-gnu
@@ -9,8 +9,9 @@ LABEL maintainer "Marc Carre <carre.marc@gmail.com>"
 RUN apt-get update && apt-get install -y \
         curl \
         gcc \
+	gpg \
         inotify-tools && \
-    gpg --keyserver pgp.mit.edu --recv-key 85AB96E6FA1BE5FE && \
+    gpg --keyserver keyserver.ubuntu.com --recv-key 85AB96E6FA1BE5FE && \
     curl -fsSO https://static.rust-lang.org/dist/rust-"$RUST_VERSION"-"$RUST_CPU"-"$RUST_ARCH".tar.gz.asc && \
     curl -fsSO https://static.rust-lang.org/dist/rust-"$RUST_VERSION"-"$RUST_CPU"-"$RUST_ARCH".tar.gz && \
     gpg --verify rust-"$RUST_VERSION"-"$RUST_CPU"-"$RUST_ARCH".tar.gz.asc && \


### PR DESCRIPTION
I ran into an issue using the latest version of rust docker environment, i.e.
```bash
# RUST_LOG=cargo=debug cargo update
DEBUG:cargo::update: executing; cmd=cargo-update; args=["cargo", "update"]
DEBUG:cargo::core::workspace: find_root - trying /home/Cargo.toml
DEBUG:cargo::core::workspace: find_root - trying /Cargo.toml
DEBUG:cargo::core::workspace: find_members - only me as a member
DEBUG:cargo::core::registry: load/missing  file:///home/rust
DEBUG:cargo::sources::config: loading: file:///home/rust
DEBUG:cargo::core::resolver: initial activation: files v0.1.0 (file:///home/rust)
DEBUG:cargo::core::registry: load/missing  registry https://github.com/rust-lang/crates.io-index
DEBUG:cargo::sources::config: loading: registry https://github.com/rust-lang/crates.io-index
    Updating registry `https://github.com/rust-lang/crates.io-index`
DEBUG:cargo: handle_cli_error; err=CliError { error: Some(ChainedError { error: failed to load source
for a dependency on `url`, cause: ChainedError { error: Unable to update registry 
https://github.com/rust-lang/crates.io-index, cause: ChainedError { error: failed to fetch 
`https://github.com/rust-lang/crates.io-index`, cause: Error { code: -17, klass: 16, message: 
"The SSL certificate is invalid" } } } }), unknown: false, exit_code: 101 }
```
I think it is related to an outdated ca-certificates package. Since debian jessie is quite old, I updated the debian version from jessie to bullseye. I also had to add ``gpg`` to the build dependencies and also had to add a different key server (I ran into connection timeout issues). Build performed via:
``` bash
docker build -t rust-docker-dev-env --build-arg rust_version=1.54.0 . 
```

P.S.: Thanks for the initial work! Great job!